### PR TITLE
MT-125 게시글 생성 오류 수정

### DIFF
--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -13,6 +13,7 @@ import { setKeyword } from '../../redux/modules/keywordImgSlice';
 import axios from 'axios';
 import HeaderLogo from '../../components/HeaderLogo';
 import { useNavigate } from 'react-router';
+import { deleteAll } from '../../redux/modules/postSlice';
 
 interface JourneyImage {
   id: number;
@@ -65,7 +66,8 @@ const Home: React.FC = () => {
   }, []);
 
   const onClickAddButton = () => {
-    navigate('/posting', { state: { new: true } });
+    dispatch(deleteAll());
+    navigate('/posting');
   };
 
   return (

--- a/src/pages/MyPageMain/index.tsx
+++ b/src/pages/MyPageMain/index.tsx
@@ -11,6 +11,8 @@ import { ReactComponent as ProfileIcon } from '../../asset/profileNone.svg';
 import * as hs from '../Home/homeStyle';
 import share from '../../asset/share.svg';
 import addPostButton from '../../asset/addPostButton.svg';
+import { useDispatch } from 'react-redux';
+import { deleteAll } from '../../redux/modules/postSlice';
 
 const MENUS = {
   '비밀번호 재설정': '/resetpassword',
@@ -23,6 +25,7 @@ const MENUS = {
 
 const MyPageMain = () => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const storedData = sessionStorage.getItem('userData');
   const userData = storedData ? JSON.parse(storedData) : null;
   console.log(userData);
@@ -40,7 +43,8 @@ const MyPageMain = () => {
   };
 
   const onClickAddButton = () => {
-    navigate('/posting', { state: { new: true } });
+    navigate('/posting');
+    dispatch(deleteAll());
   };
 
   return (

--- a/src/pages/Posting/postingComponents/ImageUpload.tsx
+++ b/src/pages/Posting/postingComponents/ImageUpload.tsx
@@ -3,14 +3,13 @@ import styled from 'styled-components';
 import { ReactComponent as None } from '../../../asset/imageNone.svg';
 import { PostingContainer } from '..';
 import { useDispatch } from 'react-redux';
-import { setImage } from '../../../redux/modules/postSlice';
+import { setImage, setPreview } from '../../../redux/modules/postSlice';
 
 interface UploadProps {
   url?: string;
-  setPreivew: React.Dispatch<React.SetStateAction<File | null>>;
 }
 
-function ImageUpload({ url, setPreivew }: UploadProps) {
+function ImageUpload({ url }: UploadProps) {
   const dispatch = useDispatch();
   const [previewPath, setPreviewPath] = useState<string | null>(null);
 
@@ -18,7 +17,7 @@ function ImageUpload({ url, setPreivew }: UploadProps) {
     const file = e.target.files?.[0];
 
     if (file) {
-      setPreivew(file);
+      dispatch(setPreview(file));
       setPreviewPath(URL.createObjectURL(file));
       dispatch(
         setImage([{ id: 0, path: URL.createObjectURL(file), sequence: 0 }])

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -6,11 +6,17 @@ import Header from '../../components/Header';
 import FormInput from '../../components/FormInput';
 import BirthdayInput from '../../components/BirthdayInput';
 import RequiredInputSelect from '../../components/RequiredInputSelect';
-import {CheckBox, Spacer, Text, InputLabel, ErrMessage} from '../../components/@atoms';
+import {
+  CheckBox,
+  Spacer,
+  Text,
+  InputLabel,
+  ErrMessage
+} from '../../components/@atoms';
 
 import BottomAlert from '../../components/Alert';
 
-import {postSignup} from '../../apis/api/signupApi';
+import { postSignup } from '../../apis/api/signupApi';
 
 type SignupInput = {
   email: string;
@@ -23,7 +29,6 @@ type SignupInput = {
 };
 
 function Signup() {
-
   const [input, setInput] = useState<SignupInput>({
     email: '',
     password: '',
@@ -36,7 +41,7 @@ function Signup() {
 
   const [isValid, setIsValid] = useState({
     isPasswordValid: true,
-    isNicknameValid: true,
+    isNicknameValid: true
   });
 
   const [eventTerm, setEventTerm] = useState(false);
@@ -54,7 +59,7 @@ function Signup() {
     use: '이용약관 동의',
     privacy: '개인정보 수집 및 이용에 대한 동의',
     marketing: '개인정보 수집 및 이용안내'
-};
+  };
 
   // !! TODO 이메일, 비밀번호 유효성 검사
   // !! 생일 input 숫자만 입력 제한
@@ -96,24 +101,29 @@ function Signup() {
     console.log(`Selected index: ${selected}`);
   };
 
-  const handleSignup = async() => {
-    try{
+  const handleSignup = async () => {
+    try {
       const { email, password, name, birthDate, nickName: nickname } = input;
       if (birthDate === null) {
         console.log('Birth date is not selected');
         return;
       }
-      const response = await postSignup({ email, password, name, birth: birthDate, nickname });
+      const response = await postSignup({
+        email,
+        password,
+        name,
+        birth: birthDate,
+        nickname
+      });
       // response 데이터 저장하는 로직 추가
-      // console.log(response);
+      console.log(response);
       setIsAlertOpen(true);
-    } catch(err) {
+    } catch (err) {
       console.log(err);
     }
 
     // 유효성 검사 로직 추가
     // 배경 블러처리, 클릭 막기
-
   };
 
   const handleCloseAlert = () => {
@@ -154,10 +164,7 @@ function Signup() {
             value={input.passwordCheck}
             isCompulsory={true}
           />
-          <ErrMessage
-            errMsg='다시 확인'
-            isError={!isValid.isPasswordValid}
-            />
+          <ErrMessage errMsg='다시 확인' isError={!isValid.isPasswordValid} />
           <Spacer height={33} />
           <FormInput
             label='이름'
@@ -186,11 +193,11 @@ function Signup() {
           <RequiredInputSelect
             onSelectedChange={handleSelectedChange}
             label='이벤트 정보'
-            values={['수신','비수신']}
+            values={['수신', '비수신']}
           />
           <Spacer height={33} />
           <InputLabel label='사이트 이용을 위한 약관에 동의' />
-          <Spacer height={12}/>
+          <Spacer height={12} />
           <CheckBox
             name='all'
             label='전체 동의'
@@ -210,11 +217,11 @@ function Signup() {
                   isChecked={term[termKey]}
                   handleCheck={handleTermChange}
                 />
-                <Spacer height={8}/>
+                <Spacer height={8} />
               </div>
             );
           })}
-          <Spacer height={30}/>
+          <Spacer height={30} />
 
           {/* 약관 동의 추가 필요 */}
           <ss.SubmitBtn onClick={handleSignup}>확인</ss.SubmitBtn>
@@ -239,12 +246,12 @@ interface OverlayProps {
 }
 
 const Overlay = styled.div<OverlayProps>`
-    display: ${({modalOpen}) => modalOpen ? 'block' : 'none'};
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    z-index: 99;
+  display: ${({ modalOpen }) => (modalOpen ? 'block' : 'none')};
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 99;
 `;

--- a/src/redux/modules/postSlice.tsx
+++ b/src/redux/modules/postSlice.tsx
@@ -3,11 +3,10 @@ import { DataProps, ImageProps } from '../../types/postData';
 import dayjs from 'dayjs';
 import { addDays } from 'date-fns';
 
-const userId = sessionStorage.getItem('myId');
-
 interface PostState {
   data: DataProps;
   image: ImageProps[];
+  preview: File | null;
 }
 
 const initialState: PostState = {
@@ -23,7 +22,7 @@ const initialState: PostState = {
     longitude: 0.0,
     tag: '',
     status: 'ACTIVE',
-    memberId: userId ? parseInt(userId) : 0
+    memberId: 0
   },
   image: [
     {
@@ -31,18 +30,25 @@ const initialState: PostState = {
       path: '',
       sequence: 0
     }
-  ]
+  ],
+  preview: null
 };
 
 const postSlice = createSlice({
   name: 'post',
   initialState,
   reducers: {
+    setMemberId: (state, action: PayloadAction<number>) => {
+      state.data.memberId = action.payload;
+    },
     setData: (state, action: PayloadAction<DataProps>) => {
       state.data = action.payload;
     },
     setImage: (state, action: PayloadAction<ImageProps[]>) => {
       state.image = action.payload;
+    },
+    setPreview: (state, action: PayloadAction<File>) => {
+      state.preview = action.payload;
     },
     deleteAll: (state) => {
       return initialState;
@@ -50,5 +56,6 @@ const postSlice = createSlice({
   }
 });
 
-export const { setData, setImage, deleteAll } = postSlice.actions;
+export const { setMemberId, setData, setImage, setPreview, deleteAll } =
+  postSlice.actions;
 export default postSlice.reducer;


### PR DESCRIPTION
- 빈 항목이 있을 때 저장을 누르면 튕기는 오류를 수정했습니다.
- 새 게시글을 작성할 때 다른 글의 데이터가 유지되는 것을 고쳤습니다.
- 게시글 생성이 안되는 오류를 수정했습니다.
-> 기존의 프리뷰 파일을 useState에서 redux-persist에 저장하도록 변경했습니다. 
-> 유저 아이디를 게시글 생성 페이지에서 받아오도록 변경했습니다.