### PR TITLE
refactor: 동행글 목록 get api 모듈화, 댓글 관련 오류 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React, { useEffect } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { GlobalStyle } from './styles/GlobalStyles';
 import BottomNav from './components/BottomNav';
@@ -20,17 +19,16 @@ import Signup from './pages/Signup';
 import TabMenu from './components/@atoms/TabMenu';
 import NoticeBoard from './pages/NoticeBoard';
 import FAQ from './pages/FAQ';
-import CompanionList from './pages/CompanionList';
 import MyInterestedCompanionLog from './pages/MyInterestedCompanionLog';
 import MyPostWrote from './pages/MyPostWrote';
 import Detail from './pages/Detail';
 import Comments from './pages/Comments';
 import PopularTravel from './pages/PopularTravel';
-import TopNav from './components/TopNav';
 import Posting from './pages/Posting';
 import ScrollToTop from './utils/scrollToTop';
 import Terms from './pages/Terms';
 import Privacy from './pages/Privacy';
+import CompanionList from './pages/CompanionList';
 
 function App() {
   const serviceTabs = [

--- a/src/apis/api/journey.ts
+++ b/src/apis/api/journey.ts
@@ -1,5 +1,32 @@
 import { baseAPI } from '../axiosInstance';
 
+export const getJourneyList = async () => {
+  try {
+    const { data } = await baseAPI.get('/journeys');
+    return data;
+  } catch (error) {
+    console.log('get journey list fail:', error);
+  }
+};
+
+export const getInterestList = async (id: number) => {
+  try {
+    const { data } = await baseAPI.get(`/journeys/interest?memberId=${id}`);
+    return data;
+  } catch (error) {
+    console.log('get interest list fail:', error);
+  }
+};
+
+export const getMyPostList = async (id: number) => {
+  try {
+    const { data } = await baseAPI.get(`/journeys/mypage?memberId=${id}`);
+    return data;
+  } catch (error) {
+    console.log('get my post list fail:', error);
+  }
+};
+
 export const getJourneyDetail = async (id: number) => {
   try {
     const { data } = await baseAPI.get(`/journeys/${id}`);

--- a/src/components/@atoms/CommentInput.tsx
+++ b/src/components/@atoms/CommentInput.tsx
@@ -7,25 +7,27 @@ import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { deleteAll, selectParentId } from '../../redux/modules/replySlice';
 import { useDispatch } from 'react-redux';
+import { useUserId } from '../../hooks/useUserId';
 
 type CommentType = {
   journeyId: number;
-  memberId: number;
   newComment?: boolean;
   setNew?: React.Dispatch<React.SetStateAction<boolean>>;
   inputFocus?: React.RefObject<HTMLInputElement>;
+  writerId?: number;
 };
 
 function CommentInput({
   journeyId,
-  memberId,
   setNew,
   newComment,
-  inputFocus
+  inputFocus,
+  writerId
 }: CommentType) {
   const theme = useTheme();
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const userId = useUserId();
   const [input, setInput] = useState('');
   const [secret, setSecret] = useState(false);
   const parentId = useSelector(selectParentId);
@@ -41,7 +43,7 @@ function CommentInput({
       secret: secret,
       parentId: parentId,
       journeyId: journeyId,
-      memberId: memberId
+      memberId: userId
     };
 
     if (input.length > 0) {
@@ -55,7 +57,9 @@ function CommentInput({
           setNew(!newComment);
           dispatch(deleteAll());
         } else {
-          navigate(`/trip/${journeyId}/comments`);
+          navigate(`/trip/${journeyId}/comments`, {
+            state: { writerId: writerId }
+          });
         }
       });
     }

--- a/src/pages/Comments/commentsCoponents/CommentBox.tsx
+++ b/src/pages/Comments/commentsCoponents/CommentBox.tsx
@@ -7,13 +7,10 @@ import CommentCount from '../../../components/@atoms/CommentCount';
 import { encodeEmail } from '../../../utils/encodeEmail';
 import { useDispatch } from 'react-redux';
 import { useSelector } from 'react-redux';
-import {
-  deleteAll,
-  selectParentId,
-  setReply
-} from '../../../redux/modules/replySlice';
+import { deleteAll, setReply } from '../../../redux/modules/replySlice';
 import { RootState } from '../../../redux/store';
 import { useUserId } from '../../../hooks/useUserId';
+import { useLocation } from 'react-router-dom';
 
 type CommentBoxProps = {
   comment: CommentProps;
@@ -23,9 +20,10 @@ type CommentBoxProps = {
 function CommentBox({ comment, inputFocus }: CommentBoxProps) {
   const theme = useTheme();
   const dispatch = useDispatch();
+  const location = useLocation();
   const parentId = useSelector((state: RootState) => state.reply.parentId);
   const isReply = comment.parentId > 0 ? true : false;
-  const isWriter = useUserId() === comment.memberId;
+  const isWriter = useUserId() === location.state.writerId;
 
   const formatTime = (time: string) => {
     let result = time.substring(0, time.length - 10);

--- a/src/pages/Comments/index.tsx
+++ b/src/pages/Comments/index.tsx
@@ -8,7 +8,6 @@ import CommentBox from './commentsCoponents/CommentBox';
 import { CommentProps } from '../../types/commentData';
 import { getComments } from '../../apis/api/comment';
 import Header from '../../components/Header';
-import { useUserId } from '../../hooks/useUserId';
 import { sortComment } from '../../apis/services/comment';
 
 function Comments() {
@@ -16,13 +15,11 @@ function Comments() {
   const [comments, setComments] = useState<CommentProps[]>([]);
   const [newComment, setNewComment] = useState<boolean>(false);
   const inputFocus = useRef<HTMLInputElement>(null);
-  const userId = useUserId();
 
   useEffect(() => {
     const getData = async () => {
       if (id) {
         await getComments(parseInt(id), 1).then((res) => {
-          console.log('get comments success: ', res);
           const sortedComments = sortComment(res);
 
           setComments(sortedComments);
@@ -49,7 +46,6 @@ function Comments() {
           <CommentInputWrap>
             <CommentInput
               journeyId={parseInt(id!)}
-              memberId={userId}
               newComment={newComment}
               setNew={setNewComment}
               inputFocus={inputFocus}

--- a/src/pages/CompanionList/index.tsx
+++ b/src/pages/CompanionList/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import * as gs from '../../styles/GlobalStyles';
 import * as cs from './CompanionListStyle';
 import fillterIcon from '../../asset/fillterIcon.svg';

--- a/src/pages/Detail/detailComponents/Info.tsx
+++ b/src/pages/Detail/detailComponents/Info.tsx
@@ -3,11 +3,11 @@ import { ReactComponent as ArrowRight } from '../../../asset/arrowRight.svg';
 import recruitingImage from '../../../asset/recruiting.svg';
 import recruitingEndImage from '../../../asset/recruitingEnd.svg';
 import UserIntro from '../../../components/UserIntro';
-import { DataProps } from '../../../types/postData';
+import { JourneyProps } from '../../../types/postData';
 import { encodeEmail } from '../../../utils/encodeEmail';
 
 type InfoType = {
-  data: DataProps;
+  data: JourneyProps;
 };
 
 function Info({ data }: InfoType) {
@@ -16,7 +16,6 @@ function Info({ data }: InfoType) {
 
     return result;
   };
-
 
   return (
     <D.InfoContainer>

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -9,19 +9,18 @@ import Thumbnail from '../../components/@atoms/Thumbnail';
 import Plan from './detailComponents/Plan';
 import { useEffect, useState } from 'react';
 import { getJourneyDetail } from '../../apis/api/journey';
-import { DataProps, ImageProps } from '../../types/postData';
+import { JourneyProps } from '../../types/postData';
 import { getCleanDetailInfo } from '../../apis/services/journey';
 import Header from '../../components/Header';
 import { useDispatch } from 'react-redux';
-import { setData, setImage } from '../../redux/modules/postSlice';
+import { setData } from '../../redux/modules/postSlice';
 import { useUserId } from '../../hooks/useUserId';
 
 function Detail() {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const id = useParams().id;
-  const [detail, setDetail] = useState<DataProps>();
-  const [imageData, setImageData] = useState<ImageProps[]>([]);
+  const [detail, setDetail] = useState<JourneyProps>();
   const zoom = 13;
   const userId = useUserId();
 
@@ -29,12 +28,7 @@ function Detail() {
     const getData = async () => {
       if (id) {
         await getJourneyDetail(parseInt(id)).then((res) => {
-          console.log('get journey success: ', res);
           const detailData = getCleanDetailInfo(res);
-
-          setImageData(detailData.journeyImgRequestDtoList);
-
-          delete detailData['journeyImgRequestDtoList'];
           setDetail(detailData);
         });
       }
@@ -58,16 +52,15 @@ function Detail() {
 
   const onCommentClick = () => {
     if (id) {
-      return navigate(`/trip/${parseInt(id)}/comments`);
+      return navigate(`/trip/${parseInt(id)}/comments`, {
+        state: { writerId: detail?.memberId }
+      });
     }
   };
 
   const onEditClick = () => {
     if (detail) {
       dispatch(setData(detail));
-    }
-    if (imageData) {
-      dispatch(setImage(imageData));
     }
     navigate('/posting', { state: { id: parseInt(id!) } });
   };
@@ -80,7 +73,9 @@ function Detail() {
         onClick={onEditClick}
       />
       <D.DeatilMainBox>
-        <Thumbnail url={imageData ? imageData[0]?.path : ''} />
+        <Thumbnail
+          url={detail ? detail.journeyImgRequestDtoList[0].path : ''}
+        />
         {detail && (
           <>
             <Info data={detail} />
@@ -90,7 +85,10 @@ function Detail() {
             />
             {/* <Plan plan={plan} /> */}
             <D.CommentContainer>
-              <CommentInput journeyId={parseInt(id!)} memberId={1} />
+              <CommentInput
+                journeyId={parseInt(id!)}
+                writerId={detail.memberId}
+              />
               <CommentCount
                 cnt={detail.journeyCount!}
                 onClick={onCommentClick}

--- a/src/pages/Home/homeStyle.tsx
+++ b/src/pages/Home/homeStyle.tsx
@@ -1,4 +1,4 @@
-import { Link, Navigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 export const TitleBox = styled.div`

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import * as gs from '../../styles/GlobalStyles';
 import * as hs from './homeStyle';
 import addPostButton from '../../asset/addPostButton.svg';
@@ -10,32 +10,15 @@ import UserList from '../../components/UserList';
 import Search from '../../components/Search';
 import { useDispatch } from 'react-redux';
 import { setKeyword } from '../../redux/modules/keywordImgSlice';
-import axios from 'axios';
 import HeaderLogo from '../../components/HeaderLogo';
 import { useNavigate } from 'react-router';
 import { deleteAll } from '../../redux/modules/postSlice';
-
-interface JourneyImage {
-  id: number;
-  path: string;
-  sequence: number;
-}
-
-interface Journey {
-  id: number;
-  memberName: string;
-  journeyImgRequestDtoList: JourneyImage[];
-  path: string;
-  city: string;
-  title: string;
-  content: string;
-  startDate: string;
-  endDate: string;
-  totalPage: number;
-}
+import { copyLink } from '../../utils/copyLink';
+import { getJourneyList } from '../../apis/api/journey';
+import { JourneyProps } from '../../types/postData';
 
 interface Type {
-  dtoList: Journey[];
+  dtoList: JourneyProps[];
   totalPage: number;
 }
 
@@ -44,22 +27,11 @@ const Home: React.FC = () => {
   const navigate = useNavigate();
   const [journeys, setJourneys] = useState<Type>({ dtoList: [], totalPage: 0 });
 
-  const handleInviteFriend = () => {
-    const urlToCopy = 'http://matrip.s3-website.ap-northeast-2.amazonaws.com/';
-    navigator.clipboard.writeText(urlToCopy);
-    alert('링크가 복사되었습니다!');
-  };
-
   useEffect(() => {
     const fetchData = async () => {
-      try {
-        const response = await axios.get(
-          'http://ec2-3-39-190-233.ap-northeast-2.compute.amazonaws.com/journeys'
-        );
-        setJourneys(response.data || { dtoList: [] });
-      } catch (error) {
-        console.error('Error', error);
-      }
+      await getJourneyList().then((res) => {
+        setJourneys(res || { dtoList: [] });
+      });
     };
 
     fetchData();
@@ -85,8 +57,8 @@ const Home: React.FC = () => {
           {journeys.dtoList.slice(0, 5).map((data, index) => (
             <UserList
               key={index}
-              id={data.id}
-              memberName={data.memberName}
+              id={data.id!}
+              memberName={data.memberName!}
               imgurl={data.journeyImgRequestDtoList[0]?.path}
               city={data.city}
               title={data.title}
@@ -125,7 +97,7 @@ const Home: React.FC = () => {
             </hs.PopularImgbox>
           </hs.PopularTravelBox>
 
-          <hs.InviteFriend onClick={() => handleInviteFriend()}>
+          <hs.InviteFriend onClick={() => copyLink()}>
             친구 초대하기 <hs.InviteFriendImg src={share} />
           </hs.InviteFriend>
 

--- a/src/pages/MyInterestedCompanionLog/index.tsx
+++ b/src/pages/MyInterestedCompanionLog/index.tsx
@@ -3,55 +3,26 @@ import * as mcl from './myCompanionLogStyle';
 import UserList from '../../components/UserList';
 import listIcon from '../../asset/listIcon.svg';
 import TitleIcon from '../../asset/titleIcon.svg';
-import axios from 'axios';
-import { useParams } from 'react-router-dom';
-
-interface JourneyImage {
-  id: number;
-  path: string;
-  sequence: number;
-}
-
-interface Journey {
-  id: number;
-  memberName: string;
-  journeyImgRequestDtoList: JourneyImage[];
-  path: string;
-  city: string;
-  title: string;
-  content: string;
-  startDate: string;
-  endDate: string;
-}
-
-interface Type {
-  dtoList: Journey[];
-}
+import { useUserId } from '../../hooks/useUserId';
+import { getInterestList } from '../../apis/api/journey';
+import { JourneyProps } from '../../types/postData';
 
 const MyInterestedCompanionLog: React.FC = () => {
-  const storedId = sessionStorage.getItem('myId');
-
-  const { id = storedId || '1' } = useParams();
+  const userId = useUserId();
   const initialDisplayCount = 5;
   const [displayCount, setDisplayCount] = useState(initialDisplayCount);
   const [isListIconClicked, setListIconClicked] = useState(true);
-  const [journeys, setJourneys] = useState<Type>({ dtoList: [] });
+  const [journeys, setJourneys] = useState<JourneyProps[]>([]);
 
   useEffect(() => {
     const fetchData = async () => {
-      try {
-        const response = await axios.get(
-          `http://ec2-3-39-190-233.ap-northeast-2.compute.amazonaws.com/journeys/interest?memberId=${id}`
-        );
-        setJourneys({ dtoList: response.data.dtoList || [] });
-      } catch (error) {
-        console.error('Error fetching data:', error);
-        setJourneys({ dtoList: [] });
-      }
+      await getInterestList(userId).then((res) => {
+        setJourneys(res || []);
+      });
     };
 
     fetchData();
-  }, [id]);
+  }, [userId]);
 
   // 감지할 스크롤 이벤트 추가
   useEffect(() => {
@@ -92,15 +63,15 @@ const MyInterestedCompanionLog: React.FC = () => {
         ></mcl.TitleIcon>
       </mcl.TitleListIconBox>
       <mcl.DataUserPost>
-        {journeys.dtoList.length === 0 ? (
+        {journeys.length === 0 ? (
           <mcl.noPost>게시글이 없어요.</mcl.noPost>
         ) : (
-          journeys.dtoList.slice(0, displayCount).map((data, index) => {
+          journeys.slice(0, displayCount).map((data, index) => {
             return (
               <UserList
                 key={index}
-                id={data.id}
-                memberName={data.memberName}
+                id={data.id!}
+                memberName={data.memberName!}
                 imgurl={data.journeyImgRequestDtoList[0]?.path}
                 city={data.city}
                 title={data.title}

--- a/src/pages/MyPostWrote/index.tsx
+++ b/src/pages/MyPostWrote/index.tsx
@@ -4,57 +4,26 @@ import * as gs from '../../styles/GlobalStyles';
 import UserList from '../../components/UserList';
 import listIcon from '../../asset/listIcon.svg';
 import TitleIcon from '../../asset/titleIcon.svg';
-import axios from 'axios';
-import { useParams } from 'react-router-dom';
-import { getJourneyDetail } from '../../apis/api/journey';
-
-interface JourneyImage {
-  id: number;
-  path: string;
-  sequence: number;
-}
-
-interface Journey {
-  id: number;
-  memberName: string;
-  journeyImgRequestDtoList: JourneyImage[];
-  path: string;
-  city: string;
-  title: string;
-  content: string;
-  startDate: string;
-  endDate: string;
-}
-
-interface Type {
-  dtoList: Journey[];
-}
+import { useUserId } from '../../hooks/useUserId';
+import { getMyPostList } from '../../apis/api/journey';
+import { JourneyProps } from '../../types/postData';
 
 const MyPostWrote: React.FC = () => {
-  const storedId = sessionStorage.getItem('myId');
-
-  // 만약 세션에 id 값이 없으면 기본값을 사용
-  const { id = storedId || '1' } = useParams();
+  const userId = useUserId();
   const initialDisplayCount = 5;
   const [displayCount, setDisplayCount] = useState(initialDisplayCount);
   const [isListIconClicked, setListIconClicked] = useState(true);
-  const [journeys, setJourneys] = useState<Type>({ dtoList: [] });
+  const [journeys, setJourneys] = useState<JourneyProps[]>([]);
 
   useEffect(() => {
     const fetchData = async () => {
-      try {
-        const response = await axios.get(
-          `http://ec2-3-39-190-233.ap-northeast-2.compute.amazonaws.com/journeys/mypage?memberId=${id}`
-        );
-        setJourneys({ dtoList: response.data.dtoList || [] });
-      } catch (error) {
-        console.error('Error fetching data:', error);
-        setJourneys({ dtoList: [] });
-      }
+      await getMyPostList(userId).then((res) => {
+        setJourneys(res || []);
+      });
     };
 
     fetchData();
-  }, [id]);
+  }, [userId]);
 
   // 감지할 스크롤 이벤트 추가
   useEffect(() => {
@@ -92,15 +61,15 @@ const MyPostWrote: React.FC = () => {
         ></mcl.TitleIcon>
       </mcl.TitleListIconBox>
       <mcl.DataUserPost>
-        {journeys.dtoList.length === 0 ? (
+        {journeys.length === 0 ? (
           <mcl.noPost>게시글이 없어요.</mcl.noPost>
         ) : (
-          journeys.dtoList.slice(0, displayCount).map((data, index) => {
+          journeys.slice(0, displayCount).map((data, index) => {
             return (
               <UserList
                 key={index}
-                id={data.id}
-                memberName={data.memberName}
+                id={data.id!}
+                memberName={data.memberName!}
                 imgurl={data.journeyImgRequestDtoList[0]?.path}
                 city={data.city}
                 title={data.title}

--- a/src/pages/Posting/index.tsx
+++ b/src/pages/Posting/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
@@ -14,7 +14,7 @@ import TextField from './postingComponents/TextField';
 import DateSelect from './postingComponents/DateSelect';
 import LocationSelect from './postingComponents/LocationSelect';
 import Header from '../../components/Header';
-import { DataProps, ImageProps } from '../../types/postData';
+import { JourneyProps, ImageProps } from '../../types/postData';
 import { uploadImage } from '../../utils/uploadImage';
 import { postJourney, putJourney } from '../../apis/api/journey';
 import { useDispatch } from 'react-redux';
@@ -22,7 +22,7 @@ import { deleteAll } from '../../redux/modules/postSlice';
 import { useUserId } from '../../hooks/useUserId';
 
 export interface StateProps {
-  dataInput?: DataProps;
+  dataInput?: JourneyProps;
   imageInput?: ImageProps;
 }
 
@@ -31,7 +31,9 @@ function Posting() {
   const location = useLocation();
   const dispatch = useDispatch();
   const data = useSelector((state: RootState) => state.post.data);
-  const image = useSelector((state: RootState) => state.post.image);
+  const image = useSelector(
+    (state: RootState) => state.post.data.journeyImgRequestDtoList
+  );
   const preview = useSelector((state: RootState) => state.post.preview);
   const [end, setEnd] = useState(false);
   const postId = location.state?.id;

--- a/src/redux/modules/postSlice.tsx
+++ b/src/redux/modules/postSlice.tsx
@@ -1,11 +1,10 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { DataProps, ImageProps } from '../../types/postData';
+import { JourneyProps, ImageProps } from '../../types/postData';
 import dayjs from 'dayjs';
 import { addDays } from 'date-fns';
 
 interface PostState {
-  data: DataProps;
-  image: ImageProps[];
+  data: JourneyProps;
   preview: File | null;
 }
 
@@ -22,15 +21,15 @@ const initialState: PostState = {
     longitude: 0.0,
     tag: '',
     status: 'ACTIVE',
-    memberId: 0
+    memberId: 0,
+    journeyImgRequestDtoList: [
+      {
+        id: 0,
+        path: '',
+        sequence: 0
+      }
+    ]
   },
-  image: [
-    {
-      id: 0,
-      path: '',
-      sequence: 0
-    }
-  ],
   preview: null
 };
 
@@ -41,11 +40,11 @@ const postSlice = createSlice({
     setMemberId: (state, action: PayloadAction<number>) => {
       state.data.memberId = action.payload;
     },
-    setData: (state, action: PayloadAction<DataProps>) => {
+    setData: (state, action: PayloadAction<JourneyProps>) => {
       state.data = action.payload;
     },
     setImage: (state, action: PayloadAction<ImageProps[]>) => {
-      state.image = action.payload;
+      state.data.journeyImgRequestDtoList = action.payload;
     },
     setPreview: (state, action: PayloadAction<File>) => {
       state.preview = action.payload;

--- a/src/types/postData.d.ts
+++ b/src/types/postData.d.ts
@@ -1,4 +1,10 @@
-export interface DataProps {
+export interface ImageProps {
+  id: number;
+  path: string;
+  sequence: number;
+}
+
+export interface JourneyProps {
   id?: number;
   title: string;
   city: string;
@@ -16,17 +22,10 @@ export interface DataProps {
   memberName?: string;
   memberSex?: string;
   status: string;
+  journeyImgRequestDtoList: ImageProps[];
 }
 
 export interface PlanProps {
   day: number;
   content: string;
 }
-
-export interface ImageProps {
-  id: number;
-  path: string;
-  sequence: number;
-}
-
-export type DataType = DataProps & ImageProps;


### PR DESCRIPTION
- 동행, 관심 동행, 내가 작성한 글 목록 api 모듈화했습니다.
- home, myInterestedCompanionLog, myPostWrote의 index.ts에서 각각 선언했던 타입들을 postData.ts에 선언해놓은 타입들로 통일시켰습니다.
- postData.ts에서 DataProps->JourneyProps로 이름 변경, JourneyProps에 journeyImgRequestDtoList를 추가했습니다.
그에 따른 수정 사항들도 변경했습니다.
- 댓글 등록할 때 id가 1로 고정되어있던 걸 사용자 id로 변경했습니다.
- 글 작성자와 댓글 작성자가 다름에도 같다고 표시되는 오류를 해결했습니다.
댓글 페이지로 이동할 때 작성자 id를 넘겨주는 방식으로 수정했습니다.